### PR TITLE
Fix usage of sampling rates of 1000 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Redistribution is possible under the terms of the MIT license.
 
 # References
 * MAX30100: [https://datasheets.maximintegrated.com/en/ds/MAX30100.pdf](https://datasheets.maximintegrated.com/en/ds/MAX30100.pdf)
-* MAX30102: [https://datasheets.maximintegrated.com/en/ds/MAX30101.pdf](https://datasheets.maximintegrated.com/en/ds/MAX30101.pdf)
+* MAX30101: [https://datasheets.maximintegrated.com/en/ds/MAX30101.pdf](https://datasheets.maximintegrated.com/en/ds/MAX30101.pdf)
 * MAX30102: [https://datasheets.maximintegrated.com/en/ds/MAX30102.pdf](https://datasheets.maximintegrated.com/en/ds/MAX30102.pdf)
 * MAX30105: [https://datasheets.maximintegrated.com/en/ds/MAX30105.pdf](https://datasheets.maximintegrated.com/en/ds/MAX30105.pdf)
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MAX3010x Sensor Library
-version=1.0.4
+version=1.0.5
 author=Daniel Wiese
 maintainer=Daniel Wiese <contact@devxplained.eu>
 sentence=An Arduino library for the MAX3010x sensor family.

--- a/src/MAX3010x_multiLed_core.h
+++ b/src/MAX3010x_multiLed_core.h
@@ -127,6 +127,7 @@ public:
     SAMPLING_RATE_200SPS,   //!< 200 samples per second
     SAMPLING_RATE_400SPS,   //!< 400 samples per second
     SAMPLING_RATE_800SPS,   //!< 800 samples per second
+    SAMPLING_RATE_1000SPS,  //!< 1000 samples per second
     SAMPLING_RATE_1600SPS,  //!< 1600 samples per second
     SAMPLING_RATE_3200SPS   //!< 3200 samples per second
   };


### PR DESCRIPTION
- Sampling rate 1000 was missing for MAX30101, MAX30102, MAX30105
- Sampling rates above 1000 were incorrectly set for MAX30101, MAX30102, MAX30105